### PR TITLE
eslintの設定を変更

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -192,7 +192,6 @@ export default defineConfig([
         "error",
         {
           case: "camelCase",
-          // 正しい正規表現形式に修正
           ignore: ["vite-env\\.d\\.ts$", ".*\\.d\\.ts$"],
         },
       ],
@@ -210,7 +209,6 @@ export default defineConfig([
           cases: {
             pascalCase: true,
           },
-          // 正しい正規表現形式に修正
           ignore: [
             "^main\\.tsx$",
             "^router\\.tsx$",
@@ -218,6 +216,8 @@ export default defineConfig([
             ".*\\.slice\\.tsx$",
             ".*\\.context\\.tsx$",
             ".*\\.hooks\\.tsx$",
+            "^use[A-Z].*\\.tsx$",
+            "^use[A-Z].*\\.test\\.tsx$",
           ],
         },
       ],


### PR DESCRIPTION
- 不要な文字を削除
- testファイル内でuse系の単語が含まれている場合に，PascalCaseにならないように変更

# 📝 概要
テストファイルのファイル名の設定が，use系を受け付けなくなっていたので変更

## 🔗 関連Issue
なし

## 🎯 目的
hooksのテストでエラーが出るのを解消

## 📋 変更内容
- 不要な文字を削除
- testファイル内でuse系の単語が含まれている場合に，PascalCaseにならないように変更

## 🚨 注意事項
<!-- 特に確認してほしい点や懸念事項があれば記載してください -->
<!-- Copilotに特に見てほしいロジックや判断基準があれば記載しましょう -->

## 📚 参考情報
<!-- 参考にしたドキュメントやリソースへのリンクがあれば記載してください -->
