### PR TITLE
API から選択された都道府県の「人口構成」を取得する

### DIFF
--- a/src/api/endpoints/__test__/population.test.ts
+++ b/src/api/endpoints/__test__/population.test.ts
@@ -1,0 +1,122 @@
+import { http, HttpResponse } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { server } from "../../../mocks/server";
+import { isApiError, isZodError } from "../../../utils/typeGuards";
+import fetcher from "../../fetcher";
+import { getPopulation } from "../population";
+
+describe("getPopulation", () => {
+  // テスト実行前にサーバーを開始
+  beforeAll(() => server.listen());
+
+  // 各テスト後にモックリクエストハンドラーをリセット
+  afterEach(() => server.resetHandlers());
+
+  // テスト終了後にサーバーを停止
+  afterAll(() => server.close());
+
+  describe("正常系", () => {
+    it("prefCode=1（北海道）の場合、すべての人口データが取得できる", async () => {
+      const result = await getPopulation(1);
+
+      expect(result.boundaryYear).toBe(2020);
+      expect(result.data).toHaveLength(4);
+
+      // 各ラベルのデータを確認
+      const totalPopulation = result.data.find((item) => item.label === "総人口");
+      expect(totalPopulation).toBeDefined();
+      expect(totalPopulation!.data[0]).toEqual({ year: 1980, value: 5575989 });
+      expect(totalPopulation!.data[1]).toEqual({ year: 2020, value: 5224614 });
+
+      const youngPopulation = result.data.find((item) => item.label === "年少人口");
+      expect(youngPopulation).toBeDefined();
+
+      const productivePopulation = result.data.find((item) => item.label === "生産年齢人口");
+      expect(productivePopulation).toBeDefined();
+
+      const elderlyPopulation = result.data.find((item) => item.label === "老年人口");
+      expect(elderlyPopulation).toBeDefined();
+    });
+
+    it("prefCode=13（東京都）の場合、総人口のみのデータが取得できる", async () => {
+      const result = await getPopulation(13);
+
+      expect(result.boundaryYear).toBe(2020);
+      expect(result.data).toHaveLength(1);
+
+      const totalPopulation = result.data[0];
+      expect(totalPopulation.label).toBe("総人口");
+      expect(totalPopulation.data[0]).toEqual({ year: 1980, value: 11618281 });
+      expect(totalPopulation.data[1]).toEqual({ year: 2020, value: 14047594 });
+    });
+  });
+
+  describe("異常系", () => {
+    it("APIエラーが発生した場合、エラーがスローされる", async () => {
+      // モックを一時的に置き換えてエラーを発生させる
+      server.use(
+        http.get("*/population/composition/perYear", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+
+      await expect(getPopulation(1)).rejects.toThrow();
+
+      try {
+        await getPopulation(1);
+      } catch (error) {
+        expect(isApiError(error)).toBe(true);
+      }
+    });
+
+    it("ZodErrorが発生した場合、エラーメッセージがスローされる", async () => {
+      try {
+        await fetcher.get("*/population/composition/perYear");
+      } catch (error) {
+        if (isApiError(error)) {
+          expect(isZodError(error.originalError)).toBe(true);
+        }
+      }
+    });
+
+    it("予期しないエラーが発生した場合、汎用エラーメッセージがスローされる", async () => {
+      // fetcher.getを一時的にモックしてエラーを発生させる
+      const originalFetcherGet = fetcher.get;
+
+      // エラーを発生させるモック
+      fetcher.get = () => {
+        throw new Error("Network error");
+      };
+
+      await expect(getPopulation(1)).rejects.toThrow("予期しないエラーが発生しました");
+
+      // 元に戻す
+      fetcher.get = originalFetcherGet;
+    });
+  });
+
+  describe("パラメータ検証", () => {
+    it("異なるprefCodeの値で正しく動作する", async () => {
+      const results = await Promise.all([getPopulation(1), getPopulation(13)]);
+
+      expect(results[0].data).toHaveLength(4); // 北海道：4種類の人口データ
+      expect(results[1].data).toHaveLength(1); // 東京都：1種類の人口データ
+    });
+
+    it("存在しないprefCodeではエラーがスローされる", async () => {
+      await expect(getPopulation(0)).rejects.toThrow();
+      await expect(getPopulation(47)).rejects.toThrow();
+
+      try {
+        await getPopulation(999);
+      } catch (error) {
+        expect(isApiError(error)).toBe(true);
+      }
+    });
+
+    it("負の値のprefCodeでもエラーがスローされる", async () => {
+      await expect(getPopulation(-1)).rejects.toThrow();
+    });
+  });
+});

--- a/src/api/endpoints/population.ts
+++ b/src/api/endpoints/population.ts
@@ -1,12 +1,14 @@
 import { ApiResponse } from "../../types/api";
-import { Prefecture } from "../../types/domain/prefecture";
+import { PopulationCompositionPerYear } from "../../types/domain/population";
 import { isApiError } from "../../utils/typeGuards";
 import { fetcher } from "../fetcher";
 
-// 都道府県一覧を取得するAPI
-export const getPrefectures = async (): Promise<Prefecture[]> => {
+// 都道府県の人口データを取得するAPI
+export const getPopulation = async (prefCode: number): Promise<PopulationCompositionPerYear> => {
   try {
-    const response = await fetcher.get<ApiResponse<Prefecture[]>>("/prefectures");
+    const response = await fetcher.get<ApiResponse<PopulationCompositionPerYear>>(
+      `/population/composition/perYear?prefCode=${prefCode}`,
+    );
     return response.data.result;
   } catch (error) {
     if (isApiError(error)) {

--- a/src/components/molecules/PrefectureCheckbox/PrefectureCheckbox.tsx
+++ b/src/components/molecules/PrefectureCheckbox/PrefectureCheckbox.tsx
@@ -1,5 +1,5 @@
-import { Prefecture } from "../../types/domain/prefecture";
-import { Checkbox } from "../atoms/checkbox";
+import { Prefecture } from "../../../types/domain/prefecture";
+import { Checkbox } from "../../atoms/Checkbox";
 
 interface PrefectureCheckboxProps {
   prefecture: Prefecture;

--- a/src/components/molecules/PrefectureCheckbox/__test__/PrefectureCheckbox.test.tsx
+++ b/src/components/molecules/PrefectureCheckbox/__test__/PrefectureCheckbox.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { Prefecture } from "../../../types/domain/prefecture";
+import { Prefecture } from "../../../../types/domain/prefecture";
 import { PrefectureCheckbox } from "../PrefectureCheckbox";
 
 describe("PrefectureCheckbox component", () => {

--- a/src/components/molecules/PrefectureCheckbox/index.ts
+++ b/src/components/molecules/PrefectureCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { PrefectureCheckbox } from "./PrefectureCheckbox";

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -8,7 +8,7 @@ import { DashboardTemplate } from "../templates/DashboardTemplate";
 
 export function Dashboard() {
   // React Queryを使用して都道府県データを取得
-  const { prefectures, isLoading, error } = useGetPrefectures();
+  const { prefectures, isLoading, error, refetch } = useGetPrefectures();
   const [checkedPrefCodes, setCheckedPrefCodes] = useState<number[]>([]);
 
   const handlePrefectureChange = (prefCode: number, checked: boolean) => {
@@ -33,7 +33,7 @@ export function Dashboard() {
     console.error("Error fetching prefectures:", error);
     return (
       <div className="flex h-screen items-center justify-center">
-        <ErrorMessage error={error} onClick={() => window.location.reload()} />
+        <ErrorMessage error={error} onClick={() => refetch()} />
       </div>
     );
   }
@@ -45,7 +45,7 @@ export function Dashboard() {
         <ErrorMessage
           message="都道府県データが見つかりませんでした"
           title="データが見つかりません"
-          onClick={() => window.location.reload()}
+          onClick={() => refetch()}
         />
       </div>
     );

--- a/src/hooks/__test__/useGetPopulation.test.tsx
+++ b/src/hooks/__test__/useGetPopulation.test.tsx
@@ -1,0 +1,189 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { defaultConfig } from "../../api/fetcher";
+import { server } from "../../mocks/server";
+import { useGetPopulation } from "../useGetPopulation";
+
+// 実際のAPIエンドポイントを構築
+const API_BASE_URL = defaultConfig.baseURL;
+const POPULATION_ENDPOINT = `${API_BASE_URL}/population/composition/perYear`;
+
+// テスト用のQueryClientProviderラッパー
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 0,
+        gcTime: 0,
+      },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useGetPopulation", () => {
+  // テスト実行前にサーバーを開始
+  beforeAll(() => server.listen());
+
+  // 各テスト後にモックをリセット
+  afterEach(() => server.resetHandlers());
+
+  // テスト終了後にサーバーを停止
+  afterAll(() => server.close());
+
+  describe("正常系", () => {
+    it("空のprefCodesリストでは何もフェッチしない", async () => {
+      const { result } = renderHook(() => useGetPopulation([]), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.results).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasError).toBe(false);
+    });
+
+    it("単一のprefCodeでデータを正常にフェッチする", async () => {
+      const { result } = renderHook(() => useGetPopulation([1]), {
+        wrapper: createWrapper(),
+      });
+
+      // 初期状態のローディング確認
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.results[0].isLoading).toBe(true);
+
+      // データのフェッチ完了を待つ
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // 結果の確認
+      expect(result.current.results).toHaveLength(1);
+      expect(result.current.results[0].prefCode).toBe(1);
+      expect(result.current.results[0].error).toBeNull();
+      expect(result.current.results[0].data).toBeDefined();
+      expect(result.current.results[0].data?.boundaryYear).toBe(2020);
+      expect(result.current.results[0].data?.data).toHaveLength(4); // 北海道は4つのラベルデータ
+    });
+
+    it("複数のprefCodeでデータを正常にフェッチする", async () => {
+      const { result } = renderHook(() => useGetPopulation([1, 13]), {
+        wrapper: createWrapper(),
+      });
+
+      // データのフェッチ完了を待つ
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // 結果の確認
+      expect(result.current.results).toHaveLength(2);
+
+      // 北海道（prefCode: 1）の確認
+      const hokkaidoResult = result.current.results.find((r) => r.prefCode === 1);
+      expect(hokkaidoResult).toBeDefined();
+      expect(hokkaidoResult?.data?.data).toHaveLength(4);
+      expect(hokkaidoResult?.data?.data[0].label).toBe("総人口");
+      expect(hokkaidoResult?.data?.data[1].label).toBe("年少人口");
+
+      // 東京都（prefCode: 13）の確認
+      const tokyoResult = result.current.results.find((r) => r.prefCode === 13);
+      expect(tokyoResult).toBeDefined();
+      expect(tokyoResult?.data?.data).toHaveLength(1); // 東京都は総人口のみ
+      expect(tokyoResult?.data?.data[0].label).toBe("総人口");
+    });
+  });
+
+  describe("異常系", () => {
+    it("APIエラーが発生した場合、エラーがハンドリングされる", async () => {
+      // APIエラーを発生させるモック
+      server.use(
+        http.get(POPULATION_ENDPOINT, () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+
+      const { result } = renderHook(() => useGetPopulation([1]), {
+        wrapper: createWrapper(),
+      });
+
+      // エラーの発生を待つ
+      await waitFor(() => expect(result.current.hasError).toBe(true));
+
+      // エラーの確認
+      expect(result.current.results[0].error).not.toBeNull();
+      expect(result.current.results[0].data).toBeUndefined();
+    });
+
+    it("複数のリクエストで部分的にエラーが発生する場合、個別にエラーハンドリングされる", async () => {
+      // prefCode 13のみエラーを発生させる
+      server.use(
+        http.get(POPULATION_ENDPOINT, ({ request }) => {
+          const url = new URL(request.url);
+          const prefCode = url.searchParams.get("prefCode");
+
+          if (prefCode === "13") {
+            return new HttpResponse(null, { status: 500 });
+          }
+
+          // 通常のレスポンス（prefCode 1用）
+          return HttpResponse.json({
+            message: null,
+            result: {
+              boundaryYear: 2020,
+              data: [{ label: "総人口", data: [] }],
+            },
+          });
+        }),
+      );
+
+      const { result } = renderHook(() => useGetPopulation([1, 13]), {
+        wrapper: createWrapper(),
+      });
+
+      // データとエラーの混在状態の完了を待つ
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // 結果の確認
+      expect(result.current.hasError).toBe(true);
+
+      // 北海道（prefCode: 1）は成功
+      const hokkaidoResult = result.current.results.find((r) => r.prefCode === 1);
+      expect(hokkaidoResult?.error).toBeNull();
+      expect(hokkaidoResult?.data).toBeDefined();
+
+      // 東京都（prefCode: 13）はエラー
+      const tokyoResult = result.current.results.find((r) => r.prefCode === 13);
+      expect(tokyoResult?.error).not.toBeNull();
+      expect(tokyoResult?.data).toBeUndefined();
+    });
+  });
+
+  describe("機能テスト", () => {
+    it("prefCodesが動的に変更された場合、正しくクエリが更新される", async () => {
+      const { result, rerender } = renderHook((props) => useGetPopulation(props.prefCodes), {
+        wrapper: createWrapper(),
+        initialProps: { prefCodes: [1] },
+      });
+
+      // 初回フェッチ完了を待つ
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.results).toHaveLength(1);
+
+      // prefCodesを更新
+      rerender({ prefCodes: [1, 13] });
+
+      // 新しいクエリが開始されることを確認
+      expect(result.current.isLoading).toBe(true);
+
+      // すべてのフェッチ完了を待つ
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // 結果の確認
+      expect(result.current.results).toHaveLength(2);
+      expect(result.current.results.map((r) => r.prefCode)).toEqual([1, 13]);
+    });
+  });
+});

--- a/src/hooks/useGetPopulation.ts
+++ b/src/hooks/useGetPopulation.ts
@@ -1,0 +1,36 @@
+import { useQueries, UseQueryResult } from "@tanstack/react-query";
+
+import { getPopulation } from "../api/endpoints/population";
+import { PopulationCompositionPerYear } from "../types/domain/population";
+import { ApiError } from "../types/errors";
+
+interface ResultWithPrefCode {
+  prefCode: number;
+  data?: PopulationCompositionPerYear;
+  isLoading: boolean;
+  error: ApiError | null;
+}
+
+export function useGetPopulation(prefCodes: number[]) {
+  const queries: UseQueryResult<PopulationCompositionPerYear, ApiError>[] = useQueries({
+    queries: prefCodes.map((prefCode) => ({
+      queryKey: ["population", prefCode],
+      queryFn: () => getPopulation(prefCode),
+      enabled: prefCodes.length > 0,
+    })),
+  });
+
+  // prefCodeとインデックスで対応を管理
+  const results: ResultWithPrefCode[] = queries.map((query, index) => ({
+    prefCode: prefCodes[index],
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+  }));
+
+  return {
+    results,
+    isLoading: queries.some((q) => q.isLoading),
+    hasError: queries.some((q) => q.error),
+  };
+}

--- a/src/hooks/useGetPrefectures.ts
+++ b/src/hooks/useGetPrefectures.ts
@@ -9,16 +9,16 @@ export function useGetPrefectures() {
     data: prefectures,
     isLoading,
     error,
+    refetch,
   } = useQuery<Prefecture[], ApiError>({
     queryKey: ["prefectures"],
     queryFn: getPrefectures,
-    staleTime: Infinity, // 無期限に鮮度を保つ
-    gcTime: 1000 * 60 * 60 * 24 * 7, // 7日間
   });
 
   return {
     prefectures,
     isLoading,
     error,
+    refetch,
   };
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,4 @@
+export interface ApiResponse<T> {
+  message: null;
+  result: T;
+}

--- a/src/types/domain/population.ts
+++ b/src/types/domain/population.ts
@@ -12,7 +12,7 @@ export interface PopulationCategory {
 }
 
 // 人口データ
-export interface PopulationData {
+export interface PopulationCompositionPerYear {
   boundaryYear: number;
   data: PopulationCategory[];
 }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -4,5 +4,19 @@ import { AxiosError } from "axios";
 export interface ApiError {
   status: number | undefined;
   message: string;
-  originalError: AxiosError | Error;
+  originalError: AxiosError | ZodError | Error;
+}
+
+export interface ZodError {
+  success: false;
+  error: {
+    issues: Array<{
+      code: string;
+      expected: string;
+      received: string;
+      path: string[];
+      message: string;
+    }>;
+    name: "ZodError";
+  };
 }

--- a/src/utils/queryClient.ts
+++ b/src/utils/queryClient.ts
@@ -5,8 +5,8 @@ export const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       retry: 1, // 1回のリトライを許可
-      staleTime: 1000 * 60 * 5, // 5分
-      gcTime: 1000 * 60 * 15, // 15分
+      staleTime: Infinity, // 人口データは頻繁に変更されないため
+      gcTime: 1000 * 60 * 60 * 24 * 7, // 7日間
     },
   },
 });

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "../types/errors";
+import { ApiError, ZodError } from "../types/errors";
 
 export function isApiError(error: unknown): error is ApiError {
   return (
@@ -11,5 +11,20 @@ export function isApiError(error: unknown): error is ApiError {
     ((error as ApiError).status === undefined &&
       typeof (error as ApiError).message === "string" &&
       (error as ApiError).originalError instanceof Error)
+  );
+}
+
+export function isZodError(error: unknown): error is ZodError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "success" in error &&
+    (error as ZodError).success === false &&
+    "error" in error &&
+    typeof (error as ZodError).error === "object" &&
+    (error as ZodError).error !== null &&
+    "issues" in (error as ZodError).error &&
+    "name" in (error as ZodError).error &&
+    (error as ZodError).error.name === "ZodError"
   );
 }


### PR DESCRIPTION
# 📝 概要
API から選択された都道府県の「人口構成」を取得する
<!-- このPRで解決する課題や実装する機能について簡潔に説明してください -->

## 🔗 関連Issue
#21
<!-- 関連するIssue番号があれば記載してください (例: Closes #123, Relates to #456) -->

## 🎯 目的
人口構成を取得するapiを動作させる
<!-- この変更を行う理由や達成したい目標を記載してください -->

## 📋 変更内容
## <!-- 主な変更点を箇条書きで記載してください -->
- 人口構成を取得できるようにする
- ディレクトリ構成のリファクタリング
- tanstackのデフォルト設定の変更

## 🚨 注意事項

<!-- 特に確認してほしい点や懸念事項があれば記載してください -->
<!-- Copilotに特に見てほしいロジックや判断基準があれば記載しましょう -->

## 📚 参考情報

<!-- 参考にしたドキュメントやリソースへのリンクがあれば記載してください -->
