### PR TITLE
人口構成を選ぶダイアログ追加　+ ローディング処理の強化

### DIFF
--- a/src/components/atoms/select/Select.tsx
+++ b/src/components/atoms/select/Select.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface SelectProps {
+  id: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  options: {
+    value: string;
+    label: string;
+  }[];
+  className?: string;
+}
+
+export function Select({ id, value, onChange, options, className = "" }: SelectProps) {
+  return (
+    <select
+      className={`rounded-md border p-2 ${className}`}
+      id={id}
+      value={value}
+      onChange={onChange}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/atoms/select/index.ts
+++ b/src/components/atoms/select/index.ts
@@ -1,0 +1,1 @@
+export { Select } from "./Select";

--- a/src/components/molecules/LabeledSelect/LabeledSelect.tsx
+++ b/src/components/molecules/LabeledSelect/LabeledSelect.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { Select } from "@/components/atoms/select";
+
+interface LabeledSelectProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  options: {
+    value: string;
+    label: string;
+  }[];
+  className?: string;
+}
+
+export function LabeledSelect({
+  id,
+  label,
+  value,
+  onChange,
+  options,
+  className = "",
+}: LabeledSelectProps) {
+  return (
+    <div className={`flex items-center ${className}`}>
+      <label className="mr-2 font-medium" htmlFor={id}>
+        {label}:
+      </label>
+      <Select id={id} options={options} value={value} onChange={onChange} />
+    </div>
+  );
+}

--- a/src/components/molecules/LabeledSelect/index.ts
+++ b/src/components/molecules/LabeledSelect/index.ts
@@ -1,0 +1,1 @@
+export { LabeledSelect } from "./LabeledSelect";

--- a/src/components/organisms/PopulationChart.tsx
+++ b/src/components/organisms/PopulationChart.tsx
@@ -1,0 +1,42 @@
+import { PopulationByYear } from "@/types/domain/chart";
+
+import { ErrorMessage } from "../molecules/ErrorMessage";
+import { Loading } from "../molecules/Loading";
+import { MultiLineChart } from "../molecules/MultiLineChart";
+
+interface PopulationChartProps {
+  data: PopulationByYear[];
+  isLoading: boolean;
+  error: boolean;
+}
+export default function PopulationChart({ data, isLoading, error }: PopulationChartProps) {
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <ErrorMessage
+          message="人口構成データの取得中にエラーが発生しました"
+          onClick={() => window.location.reload()}
+        />
+      </div>
+    );
+  }
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loading size="lg" />
+      </div>
+    );
+  }
+  if (!data || data.length === 0) {
+    return (
+      <p className="py-8 text-center text-lg text-secondary">
+        都道府県を選択すると人口推移グラフが表示されます
+      </p>
+    );
+  }
+  return (
+    <div className="h-full w-full">
+      <MultiLineChart data={data} />
+    </div>
+  );
+}

--- a/src/components/organisms/PrefectureCheckboxList.tsx
+++ b/src/components/organisms/PrefectureCheckboxList.tsx
@@ -1,11 +1,18 @@
 import { Prefecture } from "@/types/domain/prefecture";
+import { ApiError } from "@/types/errors";
 
 import { PrefectureCheckbox } from "@/components/molecules/PrefectureCheckbox";
 
+import { ErrorMessage } from "../molecules/ErrorMessage";
+import { Loading } from "../molecules/Loading";
+
 interface PrefectureCheckboxListProps {
-  prefectures: Prefecture[];
+  prefectures?: Prefecture[];
   checkedPrefCodes: number[];
   onPrefectureChange: (prefCode: number, checked: boolean) => void;
+  isLoading: boolean;
+  error: ApiError | null;
+  refetch: () => void;
 }
 
 /**
@@ -18,7 +25,39 @@ export function PrefectureCheckboxList({
   prefectures,
   checkedPrefCodes,
   onPrefectureChange,
+  isLoading,
+  error,
+  refetch,
 }: PrefectureCheckboxListProps) {
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <ErrorMessage
+          message="人口データの取得中にエラーが発生しました"
+          onClick={() => refetch()}
+        />
+      </div>
+    );
+  }
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loading size="lg" />
+      </div>
+    );
+  }
+  if (!prefectures || prefectures.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <ErrorMessage
+          message="都道府県データが見つかりませんでした"
+          title="データが見つかりません"
+          onClick={() => refetch()}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:grid-cols-4">
       {prefectures.map((prefecture) => (

--- a/src/components/organisms/__test__/PrefectureCheckboxList.test.tsx
+++ b/src/components/organisms/__test__/PrefectureCheckboxList.test.tsx
@@ -18,6 +18,9 @@ describe("PrefectureCheckboxList component", () => {
     prefectures: mockPrefectures,
     checkedPrefCodes: [],
     onPrefectureChange: vi.fn(),
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   };
 
   beforeEach(() => {
@@ -65,7 +68,10 @@ describe("PrefectureCheckboxList component", () => {
     render(
       <PrefectureCheckboxList
         checkedPrefCodes={[]}
+        error={null}
+        isLoading={false}
         prefectures={mockPrefectures}
+        refetch={vi.fn()}
         onPrefectureChange={onPrefectureChange}
       />,
     );
@@ -86,7 +92,10 @@ describe("PrefectureCheckboxList component", () => {
     render(
       <PrefectureCheckboxList
         checkedPrefCodes={[1]} // 北海道はチェック済み
+        error={null}
+        isLoading={false}
         prefectures={mockPrefectures}
+        refetch={vi.fn()}
         onPrefectureChange={onPrefectureChange}
       />,
     );
@@ -105,7 +114,10 @@ describe("PrefectureCheckboxList component", () => {
     render(
       <PrefectureCheckboxList
         checkedPrefCodes={[]}
+        error={null}
+        isLoading={false}
         prefectures={[]}
+        refetch={vi.fn()}
         onPrefectureChange={defaultProps.onPrefectureChange}
       />,
     );

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -40,10 +40,12 @@ export function Dashboard() {
   return (
     <DashboardTemplate
       checkedPrefCodes={checkedPrefCodes}
+      isPopulationLoading={isPopulationLoading}
       isPrefError={prefError}
       isPrefLoading={isPrefLoading}
       isPrefRefetch={prefRefech}
       populationData={populationData}
+      populationHasError={populationHasError}
       populationTypeOptions={POPULATION_TYPES}
       prefectures={prefectures}
       selectedPopulationType={selectedPopulationType}

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -1,10 +1,7 @@
-import { ErrorMessage } from "@/components/molecules/ErrorMessage";
-import { Loading } from "@/components/molecules/Loading";
 import { DashboardTemplate } from "@/components/templates/DashboardTemplate";
 
 import { useGetPrefectures } from "@/hooks/useGetPrefectures";
 import { usePrefecturePopulation } from "@/hooks/usePrefecturePopulation";
-import { isApiError } from "@/utils/typeGuards";
 
 export function Dashboard() {
   // React Queryを使用して都道府県データを取得
@@ -24,53 +21,13 @@ export function Dashboard() {
     hasError: populationHasError,
   } = usePrefecturePopulation(prefectures || [], "総人口");
 
-  // 都道府県または人口データのどちらかがロード中の場合
-  if (isPrefLoading || (checkedPrefCodes.length > 0 && isPopulationLoading)) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Loading size="lg" />
-      </div>
-    );
-  }
-
-  // 都道府県データ取得のエラー時の表示
-  if (prefError && isApiError(prefError)) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <ErrorMessage error={prefError} onClick={() => prefRefech()} />
-      </div>
-    );
-  }
-
-  // 人口データ取得のエラー時の表示（都道府県が選択されている場合のみ）
-  if (checkedPrefCodes.length > 0 && populationHasError) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <ErrorMessage
-          message="人口データの取得中にエラーが発生しました"
-          onClick={() => window.location.reload()}
-        />
-      </div>
-    );
-  }
-
-  // データがない場合の表示
-  if (!prefectures || prefectures.length === 0) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <ErrorMessage
-          message="都道府県データが見つかりませんでした"
-          title="データが見つかりません"
-          onClick={() => prefRefech()}
-        />
-      </div>
-    );
-  }
-
   // データがロードできた場合、テンプレートを表示
   return (
     <DashboardTemplate
       checkedPrefCodes={checkedPrefCodes}
+      isPrefError={prefError}
+      isPrefLoading={isPrefLoading}
+      isPrefRefetch={prefRefech}
       populationData={populationData}
       prefectures={prefectures}
       onPrefectureChange={handlePrefectureChange}

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -1,9 +1,20 @@
+import { useState } from "react";
+
 import { DashboardTemplate } from "@/components/templates/DashboardTemplate";
 
 import { useGetPrefectures } from "@/hooks/useGetPrefectures";
 import { usePrefecturePopulation } from "@/hooks/usePrefecturePopulation";
 
+export type PopulationType = "総人口" | "年少人口" | "生産年齢人口" | "老年人口";
+export const POPULATION_TYPES: { value: PopulationType; label: string }[] = [
+  { value: "総人口", label: "総人口" },
+  { value: "年少人口", label: "年少人口" },
+  { value: "生産年齢人口", label: "生産年齢人口" },
+  { value: "老年人口", label: "老年人口" },
+];
+
 export function Dashboard() {
+  const [selectedPopulationType, setSelectedPopulationType] = useState<PopulationType>("総人口");
   // React Queryを使用して都道府県データを取得
   const {
     prefectures,
@@ -12,6 +23,10 @@ export function Dashboard() {
     refetch: prefRefech,
   } = useGetPrefectures();
 
+  const handlePopulationTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedPopulationType(e.target.value as PopulationType);
+  };
+
   // 都道府県選択状態をURLクエリパラメータで管理
   const {
     checkedPrefCodes,
@@ -19,7 +34,7 @@ export function Dashboard() {
     populationData,
     isLoading: isPopulationLoading,
     hasError: populationHasError,
-  } = usePrefecturePopulation(prefectures || [], "総人口");
+  } = usePrefecturePopulation(prefectures || [], selectedPopulationType);
 
   // データがロードできた場合、テンプレートを表示
   return (
@@ -29,7 +44,10 @@ export function Dashboard() {
       isPrefLoading={isPrefLoading}
       isPrefRefetch={prefRefech}
       populationData={populationData}
+      populationTypeOptions={POPULATION_TYPES}
       prefectures={prefectures}
+      selectedPopulationType={selectedPopulationType}
+      onPopulationTypeChange={handlePopulationTypeChange}
       onPrefectureChange={handlePrefectureChange}
     />
   );

--- a/src/components/templates/DashboardTemplate.tsx
+++ b/src/components/templates/DashboardTemplate.tsx
@@ -2,10 +2,10 @@ import { PopulationByYear } from "@/types/domain/chart";
 import { Prefecture } from "@/types/domain/prefecture";
 import { ApiError } from "@/types/errors";
 
-import { MultiLineChart } from "@/components/molecules/MultiLineChart/MultiLineChart";
 import { PrefectureCheckboxList } from "@/components/organisms/PrefectureCheckboxList";
 
 import { LabeledSelect } from "../molecules/LabeledSelect";
+import PopulationChart from "../organisms/PopulationChart";
 import { PopulationType } from "../pages/Dashboard";
 
 export interface DashboardTemplateProps {
@@ -16,6 +16,8 @@ export interface DashboardTemplateProps {
   isPrefError: ApiError | null;
   isPrefRefetch: () => void;
   populationData: PopulationByYear[];
+  isPopulationLoading: boolean;
+  populationHasError: boolean;
   selectedPopulationType: PopulationType;
   populationTypeOptions: {
     value: PopulationType;
@@ -32,6 +34,8 @@ export function DashboardTemplate({
   isPrefError,
   isPrefRefetch,
   populationData,
+  isPopulationLoading,
+  populationHasError,
   selectedPopulationType,
   populationTypeOptions,
   onPopulationTypeChange,
@@ -69,13 +73,11 @@ export function DashboardTemplate({
             onChange={onPopulationTypeChange}
           />
           <div className="mt-4 rounded-lg border border-gray-200 p-4">
-            {populationData.length > 0 ? (
-              <MultiLineChart data={populationData} />
-            ) : (
-              <p className="py-8 text-center text-lg text-secondary">
-                都道府県を選択すると人口推移グラフが表示されます
-              </p>
-            )}
+            <PopulationChart
+              data={populationData}
+              error={populationHasError}
+              isLoading={isPopulationLoading}
+            />
           </div>
         </div>
       </main>

--- a/src/components/templates/DashboardTemplate.tsx
+++ b/src/components/templates/DashboardTemplate.tsx
@@ -1,13 +1,17 @@
 import { PopulationByYear } from "@/types/domain/chart";
 import { Prefecture } from "@/types/domain/prefecture";
+import { ApiError } from "@/types/errors";
 
 import { MultiLineChart } from "@/components/molecules/MultiLineChart/MultiLineChart";
 import { PrefectureCheckboxList } from "@/components/organisms/PrefectureCheckboxList";
 
 export interface DashboardTemplateProps {
-  prefectures: Prefecture[];
+  prefectures?: Prefecture[];
   checkedPrefCodes: number[];
   onPrefectureChange: (prefCode: number, checked: boolean) => void;
+  isPrefLoading: boolean;
+  isPrefError: ApiError | null;
+  isPrefRefetch: () => void;
   populationData: PopulationByYear[];
 }
 
@@ -15,6 +19,9 @@ export function DashboardTemplate({
   prefectures,
   checkedPrefCodes,
   onPrefectureChange,
+  isPrefLoading,
+  isPrefError,
+  isPrefRefetch,
   populationData,
 }: DashboardTemplateProps) {
   return (
@@ -34,7 +41,10 @@ export function DashboardTemplate({
         </h2>
         <PrefectureCheckboxList
           checkedPrefCodes={checkedPrefCodes}
+          error={isPrefError}
+          isLoading={isPrefLoading}
           prefectures={prefectures}
+          refetch={isPrefRefetch}
           onPrefectureChange={onPrefectureChange}
         />
         <div className="mb-8">

--- a/src/components/templates/DashboardTemplate.tsx
+++ b/src/components/templates/DashboardTemplate.tsx
@@ -5,6 +5,9 @@ import { ApiError } from "@/types/errors";
 import { MultiLineChart } from "@/components/molecules/MultiLineChart/MultiLineChart";
 import { PrefectureCheckboxList } from "@/components/organisms/PrefectureCheckboxList";
 
+import { LabeledSelect } from "../molecules/LabeledSelect";
+import { PopulationType } from "../pages/Dashboard";
+
 export interface DashboardTemplateProps {
   prefectures?: Prefecture[];
   checkedPrefCodes: number[];
@@ -13,6 +16,12 @@ export interface DashboardTemplateProps {
   isPrefError: ApiError | null;
   isPrefRefetch: () => void;
   populationData: PopulationByYear[];
+  selectedPopulationType: PopulationType;
+  populationTypeOptions: {
+    value: PopulationType;
+    label: string;
+  }[];
+  onPopulationTypeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 
 export function DashboardTemplate({
@@ -23,6 +32,9 @@ export function DashboardTemplate({
   isPrefError,
   isPrefRefetch,
   populationData,
+  selectedPopulationType,
+  populationTypeOptions,
+  onPopulationTypeChange,
 }: DashboardTemplateProps) {
   return (
     <div aria-label="ダッシュボード" className="mx-10 my-10 items-center border-2 border-primary">
@@ -32,7 +44,7 @@ export function DashboardTemplate({
       >
         都道府県別人口推移
       </h1>
-      <main>
+      <main className="pl-6">
         <h2
           aria-label="都道府県セクション"
           className="mb-3 ml-2 inline-block w-auto border-2 border-secondary p-2"
@@ -47,13 +59,15 @@ export function DashboardTemplate({
           refetch={isPrefRefetch}
           onPrefectureChange={onPrefectureChange}
         />
-        <div className="mb-8">
-          <h2
-            aria-label="人口推移チャートセクション"
-            className="mt-4 ml-2 inline-block w-auto border-2 border-secondary p-2"
-          >
-            人口推移
-          </h2>
+        <div className="my-5 ml-2">
+          <LabeledSelect
+            className="mb-4"
+            id="populationType"
+            label="人口種別"
+            options={populationTypeOptions}
+            value={selectedPopulationType}
+            onChange={onPopulationTypeChange}
+          />
           <div className="mt-4 rounded-lg border border-gray-200 p-4">
             {populationData.length > 0 ? (
               <MultiLineChart data={populationData} />


### PR DESCRIPTION
# 📝 概要
人口構成を選ぶダイアログ追加することで，「総人口」の他に「年少人口」「生産年齢人口」「老年人口」も切り替えるようにダイアログを追加
<!-- このPRで解決する課題や実装する機能について簡潔に説明してください -->

## 🔗 関連Issue

<!-- 関連するIssue番号があれば記載してください (例: Closes #123, Relates to #456) -->

## 🎯 目的
ダイアログ追加で．選択できるようにする
ローディング処理を追加することで，ユーザ体験を強化
<!-- この変更を行う理由や達成したい目標を記載してください -->

## 📋 変更内容
- 人口構成から，総人口などを取得するダイアログを追加
- ローディング，エラー処理をorganism単位で実行

## 🚨 注意事項

<!-- 特に確認してほしい点や懸念事項があれば記載してください -->
<!-- Copilotに特に見てほしいロジックや判断基準があれば記載しましょう -->

## 📚 参考情報

<!-- 参考にしたドキュメントやリソースへのリンクがあれば記載してください -->
